### PR TITLE
GDAXOrder updates - optional price, size, timeInForce + new funds, rejectReason fields

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		1249E54E8E77AAA65774BB72B9364514 /* SHA3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95DA5B2C6B6BD355785B64B0E33D5557 /* SHA3.swift */; };
 		15178CC13A504C1C847917F313EA4230 /* CFB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 680111764D2F8BD4A072155D0B723293 /* CFB.swift */; };
 		1545999141978F143D09974A8BCCE4DF /* Checksum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DCF90BC3739917E1942C19169552B6B /* Checksum.swift */; };
+		16E7A1551FDEAA130043B6BE /* GDAXDoneReason.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E7A1541FDEAA120043B6BE /* GDAXDoneReason.swift */; };
 		173F8B8E226B9F008D69835FE2787E2C /* GDAXPublicClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD5D891D83C49391B3A13EBEFD8A3067 /* GDAXPublicClient.swift */; };
 		1DD06BA0F64D88ABDDE4C775C02C2403 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2730956B834A38606275D83F44AF68 /* Utils.swift */; };
 		2040E0C36A75E11A3766E224B0199362 /* RequestMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0722CDDE54410166C4C229D8F2F712DF /* RequestMiddleware.swift */; };
@@ -163,6 +164,7 @@
 		0967AC9E44CE0D4161693A9B4B7F9BC5 /* CryptoSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CryptoSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0D09B06CCED838CF5E0C261E37A35136 /* String+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+Extension.swift"; path = "Sources/CryptoSwift/String+Extension.swift"; sourceTree = "<group>"; };
 		11604076A87EA0C7021FC4589573777D /* Pods-GDAXSwift_Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-GDAXSwift_Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
+		16E7A1541FDEAA120043B6BE /* GDAXDoneReason.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GDAXDoneReason.swift; sourceTree = "<group>"; };
 		1744DCF251D63338C272B27B2C70B769 /* HMAC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HMAC.swift; path = Sources/CryptoSwift/HMAC.swift; sourceTree = "<group>"; };
 		1B9107E4067462593706D2BB4C23B853 /* CryptoSwift.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = CryptoSwift.xcconfig; sourceTree = "<group>"; };
 		24B131D6BA8D2614EA8B18493CC8037C /* Pods-GDAXSwift_Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-GDAXSwift_Example-umbrella.h"; sourceTree = "<group>"; };
@@ -576,6 +578,7 @@
 				920453501EE9AFDF004FD0EC /* GDAXLimitOrderRequest.swift */,
 				929721451EE8724800E616E9 /* GDAXLiquidity.swift */,
 				922F69711EEAF95A00C67BF0 /* GDAXMarketOrderRequest.swift */,
+				16E7A1541FDEAA120043B6BE /* GDAXDoneReason.swift */,
 				929721391EE8508A00E616E9 /* GDAXOrder.swift */,
 				920453521EE9B007004FD0EC /* GDAXOrderRequestProtocol.swift */,
 				929721431EE871E400E616E9 /* GDAXOrderStatus.swift */,
@@ -922,6 +925,7 @@
 				260838207A397BEF59A3D3E10473B85B /* HTTPMethod.swift in Sources */,
 				929721461EE8724800E616E9 /* GDAXLiquidity.swift in Sources */,
 				2040E0C36A75E11A3766E224B0199362 /* RequestMiddleware.swift in Sources */,
+				16E7A1551FDEAA130043B6BE /* GDAXDoneReason.swift in Sources */,
 				929721311EE72B8100E616E9 /* GDAXHistoricRate.swift in Sources */,
 				3566F7AF42F03AF8334DE13A161154A7 /* ResponseMiddleware.swift in Sources */,
 			);

--- a/GDAXSwift/Classes/GDAXDoneReason.swift
+++ b/GDAXSwift/Classes/GDAXDoneReason.swift
@@ -1,0 +1,13 @@
+//
+//  GDAXDoneReason.swift
+//  GDAXSwift
+//
+//  Created by Jānis Kiršteins on 2017-12-11.
+//  Copyright © 2017 Anthony Puppo. All rights reserved.
+//
+
+public enum GDAXDoneReason: String {
+
+	case canceled, filled
+
+}

--- a/GDAXSwift/Classes/GDAXOrder.swift
+++ b/GDAXSwift/Classes/GDAXOrder.swift
@@ -27,6 +27,7 @@ public struct GDAXOrder: JSONInitializable {
 	public let status: GDAXOrderStatus
 	public let settled: Bool
 	public let doneReason: GDAXDoneReason?
+	public let rejectReason: String?
 	
 	internal init(json: Any) throws {
 		var jsonData: Data?
@@ -48,7 +49,7 @@ public struct GDAXOrder: JSONInitializable {
 		let price = Double(json["price"] as? String ?? "")
 		let size = Double(json["size"] as? String ?? "")
 		let funds = Double(json["funds"] as? String ?? "")
-		
+
 		guard let productID = json["product_id"] as? String else {
 			throw GDAXError.responseParsingFailure("product_id")
 		}
@@ -96,7 +97,9 @@ public struct GDAXOrder: JSONInitializable {
 		}
 
 		let doneReason = GDAXDoneReason(rawValue: json["done_reason"] as? String ?? "")
-		
+
+		let rejectReason = json["reject_reason"] as? String
+
 		self.id = id
 		self.price = price
 		self.size = size
@@ -114,6 +117,7 @@ public struct GDAXOrder: JSONInitializable {
 		self.status = status
 		self.settled = settled
 		self.doneReason = doneReason
+		self.rejectReason = rejectReason
 	}
 	
 }

--- a/GDAXSwift/Classes/GDAXOrder.swift
+++ b/GDAXSwift/Classes/GDAXOrder.swift
@@ -26,6 +26,7 @@ public struct GDAXOrder: JSONInitializable {
 	public let executedValue: Double
 	public let status: GDAXOrderStatus
 	public let settled: Bool
+	public let doneReason: GDAXDoneReason?
 	
 	internal init(json: Any) throws {
 		var jsonData: Data?
@@ -93,6 +94,8 @@ public struct GDAXOrder: JSONInitializable {
 		guard let settled = json["settled"] as? Bool else {
 			throw GDAXError.responseParsingFailure("settled")
 		}
+
+		let doneReason = GDAXDoneReason(rawValue: json["done_reason"] as? String ?? "")
 		
 		self.id = id
 		self.price = price
@@ -110,6 +113,7 @@ public struct GDAXOrder: JSONInitializable {
 		self.executedValue = executedValue
 		self.status = status
 		self.settled = settled
+		self.doneReason = doneReason
 	}
 	
 }

--- a/GDAXSwift/Classes/GDAXOrder.swift
+++ b/GDAXSwift/Classes/GDAXOrder.swift
@@ -8,14 +8,17 @@
 
 public struct GDAXOrder: JSONInitializable {
 	
+	/* Some fields are optional. E.g. pending market orders might not 
+	   have price and size or funds. timeInForce is also not always set. */
 	public let id: String
-	public let price: Double
-	public let size: Double
+	public let price: Double?
+	public let size: Double?
+	public let funds: Double?
 	public let productID: String
 	public let side: GDAXSide
 	public let stp: GDAXSelfTradePrevention
 	public let type: GDAXOrderType
-	public let timeInForce: GDAXTimeInForce
+	public let timeInForce: GDAXTimeInForce?
 	public let postOnly: Bool
 	public let createdAt: Date
 	public let fillFees: Double
@@ -41,13 +44,9 @@ public struct GDAXOrder: JSONInitializable {
 			throw GDAXError.responseParsingFailure("id")
 		}
 		
-		guard let price = Double(json["price"] as? String ?? "") else {
-			throw GDAXError.responseParsingFailure("price")
-		}
-		
-		guard let size = Double(json["size"] as? String ?? "") else {
-			throw GDAXError.responseParsingFailure("size")
-		}
+		let price = Double(json["price"] as? String ?? "")
+		let size = Double(json["size"] as? String ?? "")
+		let funds = Double(json["funds"] as? String ?? "")
 		
 		guard let productID = json["product_id"] as? String else {
 			throw GDAXError.responseParsingFailure("product_id")
@@ -65,9 +64,7 @@ public struct GDAXOrder: JSONInitializable {
 			throw GDAXError.responseParsingFailure("type")
 		}
 		
-		guard let timeInForce = GDAXTimeInForce(rawValue: json["time_in_force"] as? String ?? "") else {
-			throw GDAXError.responseParsingFailure("time_in_force")
-		}
+		let timeInForce = GDAXTimeInForce(rawValue: json["time_in_force"] as? String ?? "")
 		
 		guard let postOnly = json["post_only"] as? Bool else {
 			throw GDAXError.responseParsingFailure("post_only")
@@ -109,6 +106,7 @@ public struct GDAXOrder: JSONInitializable {
 		self.createdAt = createdAt
 		self.fillFees = fillFees
 		self.filledSize = filledSize
+		self.funds = funds
 		self.executedValue = executedValue
 		self.status = status
 		self.settled = settled

--- a/GDAXSwift/Classes/GDAXOrderStatus.swift
+++ b/GDAXSwift/Classes/GDAXOrderStatus.swift
@@ -8,6 +8,6 @@
 
 public enum GDAXOrderStatus: String {
 	
-	case open, pending, active, done, all
+	case open, pending, active, done, all, rejected
 	
 }

--- a/GDAXSwift/Classes/GDAXProductTicker.swift
+++ b/GDAXSwift/Classes/GDAXProductTicker.swift
@@ -29,8 +29,6 @@ public struct GDAXProductTicker: JSONInitializable {
 			throw GDAXError.invalidResponseData
 		}
 		
-		print(json)
-		
 		guard let tradeID = json["trade_id"] as? Int else {
 			throw GDAXError.responseParsingFailure("trade_id")
 		}


### PR DESCRIPTION
Made price, size, and timeInForce fields optional in GDAXOrder, and added 'funds'. 

When placing market orders, 'price' is not set at all, and only one of 'size' or 'funds' is set. 

This should solve #4.