### PR TITLE
GDAXAccountHistory: Id field is an Integer instead of a String

### DIFF
--- a/GDAXSwift/Classes/GDAXAccountHistory.swift
+++ b/GDAXSwift/Classes/GDAXAccountHistory.swift
@@ -8,7 +8,7 @@
 
 public struct GDAXAccountHistory: JSONInitializable {
 	
-	public let id: String
+	public let id: Int
 	public let createdAt: Date
 	public let amount: Double
 	public let balance: Double
@@ -28,7 +28,7 @@ public struct GDAXAccountHistory: JSONInitializable {
 			throw GDAXError.invalidResponseData
 		}
 		
-		guard let id = json["id"] as? String else {
+		guard let id = json["id"] as? Int else {
 			throw GDAXError.responseParsingFailure("id")
 		}
 		

--- a/GDAXSwift/Classes/GDAXClient.swift
+++ b/GDAXSwift/Classes/GDAXClient.swift
@@ -8,8 +8,8 @@
 
 public class GDAXClient {
 	
-	public static let baseAPIURLString = "https://api.gdax.com"
-	public static let baseSandboxAPIURLString = "https://api-public.sandbox.gdax.com"
+    public static let baseAPIURLString = "https://api.pro.coinbase.com"
+    public static let baseSandboxAPIURLString = "https://api-public.sandbox.pro.coinbase.com"
 	
 	public let apiKey: String?
 	public let secret64: String?

--- a/GDAXSwift/Classes/GDAXRequestAuthenticator.swift
+++ b/GDAXSwift/Classes/GDAXRequestAuthenticator.swift
@@ -51,8 +51,10 @@ public class GDAXRequestAuthenticator {
 			
 			preHash += bodyString
 		}
+        
+        let _secret64 = secret64.padding(toLength: ((secret64.count+3)/4)*4, withPad: "=", startingAt: 0)
 		
-		guard let secret = Data(base64Encoded: secret64) else {
+		guard let secret = Data(base64Encoded: _secret64) else {
 			throw GDAXError.authenticationBuilderError("Failed to base64 decode secret")
 		}
 		


### PR DESCRIPTION
It seems the API json type for the "id" field in the GDAXAccountHistory is an Int and not a String.
This fixes the 'issue' I posted on your Github.